### PR TITLE
Fix lack of attachment support

### DIFF
--- a/src/mail/SendgridTransport.php
+++ b/src/mail/SendgridTransport.php
@@ -8,9 +8,11 @@ namespace putyourlightson\sendgrid\mail;
 use Craft;
 use Exception;
 use SendGrid;
+use SendGrid\Mail\Attachment;
 use SendGrid\Mail\EmailAddress;
 use SendGrid\Mail\Mail;
 use SendGrid\Mail\TypeException;
+use Swift_Mime_Attachment;
 use Swift_Mime_SimpleMessage;
 
 class SendgridTransport extends Transport
@@ -106,7 +108,16 @@ class SendgridTransport extends Transport
         $contentTypes = ['text/plain', 'text/html'];
 
         foreach ($message->getChildren() as $mimeEntity) {
-            if (in_array($mimeEntity->getBodyContentType(), $contentTypes)) {
+            if ($mimeEntity instanceof Swift_Mime_Attachment) {
+                $attachment = new Attachment();
+                $attachment->setContent(base64_encode($mimeEntity->getBody()));
+                $attachment->setType($mimeEntity->getContentType());
+                $attachment->setFilename($mimeEntity->getFilename());
+                $attachment->setDisposition($mimeEntity->getDisposition());
+                $attachment->setContentId($mimeEntity->getId());
+
+                $email->addAttachment($attachment);
+            } elseif (in_array($mimeEntity->getBodyContentType(), $contentTypes)) {
                 $email->addContent($mimeEntity->getBodyContentType(), $mimeEntity->getBody());
             }
         }


### PR DESCRIPTION
I can't seem to get attachments to work with this plugin, particular Commerce's attaching of PDFs. From what I can tell, this seems to be completely missing from the plugin?

Let me know what you think of the changes.